### PR TITLE
Added mutation so user can commit to helping an idea come to fruition

### DIFF
--- a/client/src/pages/TestPage/index.js
+++ b/client/src/pages/TestPage/index.js
@@ -1,10 +1,28 @@
-import { useQuery } from '@apollo/client';
-import { AUTH_BIGGIES } from '../../utils/queries.js';
+import { useQuery, useMutation } from '@apollo/client';
+import { USER_COMMIT_TO_HELP } from '../../utils/mutations.js';
+import { AUTH_BIGGIES} from '../../utils/queries.js';
 
 const TestPage = (props) => {
   const {data,error} = useQuery(AUTH_BIGGIES)
+  
+  const [testMutation, mutationObject] = useMutation(USER_COMMIT_TO_HELP, {
+    variables: {
+      
+        "helpOptionId": "61a81ed284b20dcd907511f9"
+      
+    }
+  })
 
   console.log(data?.authBiggiesReq)
+
+  const runMutation = async (params) => {
+    try{
+      let mutationResponse = await testMutation()
+      console.log(mutationResponse)
+    } catch (error) {
+      console.error(error)
+    }
+  }
 
   let mappedBs = data?.authBiggiesReq.map((item)=>{
     return (
@@ -43,6 +61,10 @@ const TestPage = (props) => {
       </p>
       <div>
         {mappedBs}
+      </div>
+      <div>
+        <p>test button here</p>
+        <button onClick={()=>{runMutation()}}>Test the Mutation</button>
       </div>
     </div>
   )

--- a/client/src/pages/TestPage/index.js
+++ b/client/src/pages/TestPage/index.js
@@ -75,10 +75,11 @@ const TestPage = (props) => {
         {mappedBs}
       </div>
       <div>
-        <p>test button here</p>
-        <button onClick={() => { runMutation(); }}>Test the Mutation</button>
-        <p>separate these two</p>
-        <button onClick={() => { runMutation2(); }}>Test the Money Mutation</button>
+        <h2 className='text-2xl text-center border-b'>Test Buttons Here</h2>
+        <div className='flex flex-row gap-2 justify-center'>
+        <button className='border p-2 bg-yellow-600 rounded' onClick={() => { runMutation(); }}>Test the User Mutation</button>
+        <button className='border p-2 bg-green-600 rounded' onClick={() => { runMutation2(); }}>Test the Money Mutation</button>
+        </div>
       </div>
     </div>
   );

--- a/client/src/pages/TestPage/index.js
+++ b/client/src/pages/TestPage/index.js
@@ -1,30 +1,42 @@
 import { useQuery, useMutation } from '@apollo/client';
 import { USER_COMMIT_TO_HELP } from '../../utils/mutations.js';
-import { AUTH_BIGGIES} from '../../utils/queries.js';
+import { AUTH_BIGGIES } from '../../utils/queries.js';
 
 const TestPage = (props) => {
-  const {data,error} = useQuery(AUTH_BIGGIES)
-  
-  const [testMutation, mutationObject] = useMutation(USER_COMMIT_TO_HELP, {
-    variables: {
-      
-        "helpOptionId": "61a81ed284b20dcd907511f9"
-      
-    }
-  })
+  const { data, error } = useQuery(AUTH_BIGGIES);
 
-  console.log(data?.authBiggiesReq)
+  const [testMutation] = useMutation(USER_COMMIT_TO_HELP, );
 
-  const runMutation = async (params) => {
-    try{
-      let mutationResponse = await testMutation()
-      console.log(mutationResponse)
+  const [testMutationForMoney] = useMutation(USER_COMMIT_TO_HELP);
+
+  const runMutation = async () => {
+    try {
+      let mutationResponse = await testMutation({
+        variables: {
+          "helpOptionId": "61a831f09eef024cac40a409"
+        }
+      });
+      console.log(mutationResponse.data);
     } catch (error) {
-      console.error(error)
+      console.error(error);
     }
-  }
+  };
 
-  let mappedBs = data?.authBiggiesReq.map((item)=>{
+  const runMutation2 = async () => {
+    try {
+      let mutationResponse2 = await testMutationForMoney({
+        variables: {
+          "helpOptionId": "61a831f09eef024cac40a40a",
+           moneyCommitted: 5
+        }
+      });
+      console.log(mutationResponse2.data);
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  let mappedBs = data?.authBiggiesReq.map((item) => {
     return (
       <div className='flex flex-col gap-1'>
         <p className='text-2xl'>{item.title}</p>
@@ -33,41 +45,43 @@ const TestPage = (props) => {
         <p>{item.sources}</p>
         <p>Deadline: {new Date(item.deadline).toLocaleDateString()}</p>
         <div className='flex flex-col gap-1'>
-        <h2 className='text-xl'>What can you do to help?</h2>
+          <h2 className='text-xl'>What can you do to help?</h2>
           {
-            item.helpOptions?.map(option=>{
+            item.helpOptions?.map(option => {
               return (
-              <div>
-                <p className='font-bold'>{option.name}</p>
-                <p>{option.description}</p>
-                <p>Number Required:{option.numOfPeople}</p>
-              </div>
-              )
+                <div>
+                  <p className='font-bold'>{option.name}</p>
+                  <p>{option.description}</p>
+                  <p>Number Required:{option.numOfPeople}</p>
+                </div>
+              );
             })
           }
         </div>
       </div>
-    )
-  })
-  
+    );
+  });
+
   return (
 
     <div className='flex flex-col bg-gray-100 gap-2 container mx-auto py-4 rounded-sm my-2 shadow- p-4'>
       <h1 className='text-3xl'>
-      This is the homepage, dude.
+        This is the homepage, dude.
       </h1>
       <p>
-      {error?.toString()}
+        {error?.toString()}
       </p>
       <div>
         {mappedBs}
       </div>
       <div>
         <p>test button here</p>
-        <button onClick={()=>{runMutation()}}>Test the Mutation</button>
+        <button onClick={() => { runMutation(); }}>Test the Mutation</button>
+        <p>separate these two</p>
+        <button onClick={() => { runMutation2(); }}>Test the Money Mutation</button>
       </div>
     </div>
-  )
-}
+  );
+};
 
-export default TestPage
+export default TestPage;

--- a/client/src/utils/mutations.js
+++ b/client/src/utils/mutations.js
@@ -85,3 +85,16 @@ export const LOGIN_USER = gql`mutation Login($password: String!, $username: Stri
     }
   }
 }`
+
+export const USER_COMMIT_TO_HELP = gql`
+mutation Mutation($helpOptionId: ID!) {
+  commitToHelp(helpOptionId: $helpOptionId) {
+    name
+    description
+    numOfPeople
+    registeredUsers {
+      _id
+    }
+  }
+}
+`

--- a/client/src/utils/mutations.js
+++ b/client/src/utils/mutations.js
@@ -87,14 +87,16 @@ export const LOGIN_USER = gql`mutation Login($password: String!, $username: Stri
 }`
 
 export const USER_COMMIT_TO_HELP = gql`
-mutation Mutation($helpOptionId: ID!) {
-  commitToHelp(helpOptionId: $helpOptionId) {
+mutation Mutation($helpOptionId: ID! $moneyCommitted: Int) {
+  commitToHelp(helpOptionId: $helpOptionId, moneyCommitted: $moneyCommitted) {
     name
     description
     numOfPeople
     registeredUsers {
       _id
     }
+    moneyReceived
+    moneyRequested
   }
 }
 `

--- a/server/schemas/resolvers.js
+++ b/server/schemas/resolvers.js
@@ -1,5 +1,5 @@
 const { AuthenticationError } = require('apollo-server-errors');
-const {Biiggie, HelpOption, User} = require('../models/index.js')
+const {Biiggie, User} = require('../models/index.js')
 const { signToken } = require('../utils/index.js');
 
 

--- a/server/schemas/resolvers.js
+++ b/server/schemas/resolvers.js
@@ -1,5 +1,5 @@
 const { AuthenticationError } = require('apollo-server-errors');
-const {Biiggie, User} = require('../models/index.js')
+const {Biiggie, User, HelpOption} = require('../models/index.js')
 const { signToken } = require('../utils/index.js');
 
 
@@ -43,6 +43,23 @@ const resolvers ={
       const token = signToken(user);
       return { token, user };
     },
+    commitToHelp: async (parent, args, context)=>{
+      console.log('Context looks like this:', context.user)
+
+      if(!context.user){
+        throw new AuthenticationError('You need to be logged in to commit to an Idea.')
+      }
+
+      console.log(context.user)
+
+      let helpOption = await HelpOption.findOneAndUpdate({id: args.helpOptionId}, {$addToSet: {registeredUsers: context.user._id}}, {new:true} )
+
+      console.log(helpOption)
+      return helpOption
+      //need to add user to the help option as a new item in the 'registeredUsers' array
+
+      //then i want to update the button to say weather 
+    }
   }
 }
 // Temp resolver for server testing

--- a/server/schemas/resolvers.js
+++ b/server/schemas/resolvers.js
@@ -1,6 +1,5 @@
 const { AuthenticationError } = require('apollo-server-errors');
-const Biiggie = require('../models/Biiggie.js');
-const User = require('../models/User');
+const {Biiggie, HelpOption, User} = require('../models/index.js')
 const { signToken } = require('../utils/index.js');
 
 
@@ -12,7 +11,7 @@ const resolvers ={
       return User.findOne(params);
     },
     biiggies: async ()=>{
-      return await Biiggie.find({})
+      return await Biiggie.find({}).populate('helpOptions')
     },
     authBiggiesReq: async (parent, args, context)=>{
       console.log('Context looks like this:', context.user)

--- a/server/schemas/typeDefs.js
+++ b/server/schemas/typeDefs.js
@@ -52,6 +52,7 @@ const typeDefs = gql`
     type Mutation {
         newUser(username: String, password: String, email: String, firstName: String!, lastName: String): Auth
         login(username: String!, password: String!): Auth
+        commitToHelp(helpOptionId: ID!): HelpOption
     }
     `;
 

--- a/server/schemas/typeDefs.js
+++ b/server/schemas/typeDefs.js
@@ -52,7 +52,7 @@ const typeDefs = gql`
     type Mutation {
         newUser(username: String, password: String, email: String, firstName: String!, lastName: String): Auth
         login(username: String!, password: String!): Auth
-        commitToHelp(helpOptionId: ID!): HelpOption
+        commitToHelp(helpOptionId: ID!, moneyCommitted: Int): HelpOption
     }
     `;
 

--- a/server/seeders/seed.js
+++ b/server/seeders/seed.js
@@ -18,9 +18,10 @@ connection.once('open', async () => {
             biiggie: biiggieId._id
         },
         {
-            name: 'Vehicle Wrap Installer',
-            description: 'A vehible wrap artist to install a wrap on the truck.',
-            numOfPeople: 1,
+            name: 'Donation for Vehicle Wrap',
+            description: '$100 for a Vehicle wrap artist to install a wrap on the truck.',
+            moneyRequested: 100,
+            moneyReceived: 0,
             biiggie: biiggieId._id
         },
         {


### PR DESCRIPTION
This pull request fixes #73, fixes #72, fixes #71, and fixes #43.

On the server, we have a new mutation called 'commitToHelp' that takes a HelpOption _id (args.helpOptionId) and optionally a number that represents money committed to a cause (args.moneyCommitted), and must be run by a logged in user. This mutation checks what kind of commitment the HelpOption is asking for (people or money) and updates the appropriate fields. In the resolver I implemented some simple error handling and authentication, and commented the resolver code.

On the client side I've created a new mutation string to pair with the server mutation, and  setup TestPage (link in the nav bar) to implement two buttons as examples for how to use the mutation. 
